### PR TITLE
更新 docs中新增apifox对lsky api的调用

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,9 @@ Lsky 接口的 Token
 
 获取方法可以参考这篇文章：[兰空图床LskyV2如何通过API获取Token？](https://www.52xzv.cn/archives/880.html)
 
-获取到之后把 Token 填入即可
+或采用ApiFox在线调用您的 Lsky 图床的 API 接口，获取到用户Token：[lsky-pro-v2.apifox.cn](https://lsky-pro-v2.apifox.cn/)
+
+获取到之后，把 Token 填入 yaml 即可
 
 ```yaml
 lsky-auth-token: 1|2kDE7QCXRhIWfgXC9bF3axSbCr1dBjIfRPebQ2oo


### PR DESCRIPTION
相比于原有文档外链教程中需要注册postman，使用国内的apifox更加友好，且不需要注册也能直接调用api。

更主要的一点是，避免docs里面的那篇外链博客失效或暂时无法访问（本人已经在其他地方遇到过好几次这种外链失效的情况了）